### PR TITLE
use rem units for heading font-size to avoid mobile webview jitter

### DIFF
--- a/app.css
+++ b/app.css
@@ -7,21 +7,21 @@ h1 {
   color: white;
   font-family: Montserrat, serif;
   font-weight: bold;
-  font-size: 8vh;
+  font-size: 4.5rem;
 }
 
 h2 {
   color: white;
   font-family: Montserrat, serif;
   font-weight: bold;
-  font-size: 4vh;
+  font-size: 2.25rem;
 }
 
 h3 {
   color: white;
   font-weight: lighter;
   font-family: Montserrat, serif;
-  font-size: 2.5vh;
+  font-size: 1.4rem;
 }
 
 a {
@@ -52,6 +52,15 @@ a:hover {
 
       h1 {
         width: 643px;
+        font-size: 4rem;
+      }
+
+      h2 {
+        font-size: 2rem;
+      }
+
+      h3 {
+        font-size: 1.25rem;
       }
 }
 
@@ -62,6 +71,15 @@ a:hover {
 
       h1 {
         width: 450px;
+        font-size: 3.25rem;
+      }
+
+      h2 {
+        font-size: 1.6rem;
+      }
+
+      h3 {
+        font-size: 1.05rem;
       }
 }
 
@@ -72,6 +90,15 @@ a:hover {
 
       h1 {
         width: 225px;
+        font-size: 2.5rem;
+      }
+
+      h2 {
+        font-size: 1.4rem;
+      }
+
+      h3 {
+        font-size: 1rem;
       }
 }
 


### PR DESCRIPTION
Replace viewport-height-based font sizes (vh) with rem units so
scroll-driven viewport height changes in in-app browsers like
Instagram no longer force layout reflows on every scroll frame.