### PR TITLE
fix webview text resize jitter; split h1 onto two lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,9 @@
 
   <body>
     <h1>
-      hello! i'm avi.
+      hello!
+      <br />
+      i'm avi.
     </h1>
     <h2>~</h2>
     <h2> currently</h2>


### PR DESCRIPTION
## Summary
- Replace `vh`-based heading font sizes with `rem` so scroll-driven viewport-height changes in mobile in-app webviews (Instagram, TikTok, etc.) no longer force layout reflows on every scroll frame. Added matching `font-size` rules inside the existing `max-width` media queries to preserve responsive scaling.
- Break `h1` onto two lines: "hello!" on line 1, "i'm avi." on line 2.

## Test plan
- [ ] Load the site in Instagram's in-app browser on iOS and scroll — confirm no size jitter / lag.
- [ ] Load on mobile Safari and Chrome — confirm heading sizes read similarly to the previous design at common viewport heights.
- [ ] Check desktop (>1000px), tablet (<1000px), mobile (<700px), small mobile (<450px) breakpoints — type should scale down gracefully at each.
- [ ] Confirm the `h1` renders as two lines with the new `<br />`.