### PR TITLE
conditional mobile h1 break; bump h3 weight and size

### DIFF
--- a/app.css
+++ b/app.css
@@ -19,9 +19,13 @@ h2 {
 
 h3 {
   color: white;
-  font-weight: lighter;
+  font-weight: normal;
   font-family: Montserrat, serif;
-  font-size: 1.4rem;
+  font-size: 1.65rem;
+}
+
+.mobile-only {
+  display: none;
 }
 
 a {
@@ -51,7 +55,6 @@ a:hover {
       }
 
       h1 {
-        width: 643px;
         font-size: 4rem;
       }
 
@@ -60,7 +63,7 @@ a:hover {
       }
 
       h3 {
-        font-size: 1.25rem;
+        font-size: 1.45rem;
       }
 }
 
@@ -70,7 +73,6 @@ a:hover {
       }
 
       h1 {
-        width: 450px;
         font-size: 3.25rem;
       }
 
@@ -79,7 +81,11 @@ a:hover {
       }
 
       h3 {
-        font-size: 1.05rem;
+        font-size: 1.3rem;
+      }
+
+      .mobile-only {
+        display: inline;
       }
 }
 
@@ -89,7 +95,6 @@ a:hover {
       }
 
       h1 {
-        width: 225px;
         font-size: 2.5rem;
       }
 
@@ -98,7 +103,7 @@ a:hover {
       }
 
       h3 {
-        font-size: 1rem;
+        font-size: 1.2rem;
       }
 }
 

--- a/index.html
+++ b/index.html
@@ -20,8 +20,7 @@
 
   <body>
     <h1>
-      hello!
-      <br />
+      hello!<br class="mobile-only" />
       i'm avi.
     </h1>
     <h2>~</h2>


### PR DESCRIPTION
## Summary
- `h1` line break now renders only at `<700px` via a `.mobile-only` class on the `<br>`, so desktop keeps "hello! i'm avi." on a single line while phones get the "hello!" / "i'm avi." split.
- Drop the now-redundant `h1 { width: ... }` rules in the media queries — those were forcing the awkward "hello! i'm" / "avi." wrap.
- Switch `h3` from `font-weight: lighter` (Montserrat Thin) to `normal` (Regular), and bump `h3 font-size` across all breakpoints for better readability on the blue background.

Follow-up to #9, which merged before this commit landed.

## Test plan
- [ ] Desktop (>700px): `h1` renders as "hello! i'm avi." on a single line.
- [ ] Mobile (<700px): `h1` renders as "hello!" / "i'm avi." on two lines.
- [ ] Body text (`h3`) reads clearly in Instagram's in-app webview — not faded into the background.
- [ ] Scrolling in Instagram webview still has no jitter (regression check on #9's rem fix).