### PR TITLE
switch h3 body text to Inter

### DIFF
--- a/app.css
+++ b/app.css
@@ -20,7 +20,7 @@ h2 {
 h3 {
   color: white;
   font-weight: normal;
-  font-family: Montserrat, serif;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   font-size: 1.65rem;
 }
 

--- a/index.html
+++ b/index.html
@@ -15,6 +15,12 @@
     <title>avi</title>
     <meta property="description" content="hello! i'm avi." />
 
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
     <link href="app.css" rel="stylesheet" />
   </head>
 


### PR DESCRIPTION
## Summary
- Swap `h3` (body text) from Montserrat to Inter. Montserrat is a geometric display face; on a saturated blue background, even Regular weight reads airy at body sizes. Inter is designed for screen UI at small sizes and renders noticeably heavier at the same px.
- Keep Montserrat on `h1`/`h2` so the display hierarchy stays intact.
- Load Inter from Google Fonts via `<link>` in the head (400 + 500 weights), matching common practice. `preconnect` hints included for fast connection setup.

## Test plan
- [ ] On mobile (Instagram in-app browser + Safari), body text under "currently" and "past" should feel more legible / less faded than before.
- [ ] On desktop, `h1` / `h2` still render as Montserrat Bold.
- [ ] No FOUT flash on cold load — `display=swap` + preconnect should keep it reasonable.